### PR TITLE
Add option to skip warnings when ollama is not running by default

### DIFF
--- a/src/lib/apis/ollama/index.ts
+++ b/src/lib/apis/ollama/index.ts
@@ -1,4 +1,4 @@
-import { OLLAMA_API_BASE_URL } from '$lib/constants';
+import { OLLAMA_API_BASE_URL, SKIP_WARN_WHEN_OLLAMA_NOT_PRESENT } from '$lib/constants';
 
 export const getOllamaAPIUrl = async (token: string = '') => {
 	let error = null;
@@ -92,7 +92,7 @@ export const getOllamaVersion = async (token: string = '') => {
 			return null;
 		});
 
-	if (error) {
+	if (error && !SKIP_WARN_WHEN_OLLAMA_NOT_PRESENT) {
 		throw error;
 	}
 
@@ -124,7 +124,7 @@ export const getOllamaModels = async (token: string = '') => {
 			return null;
 		});
 
-	if (error) {
+	if (error && !SKIP_WARN_WHEN_OLLAMA_NOT_PRESENT) {
 		throw error;
 	}
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -26,12 +26,12 @@ export const SUPPORTED_FILE_TYPE = [
 ];
 
 export const SUPPORTED_FILE_EXTENSIONS = [
-	'md', 'rst','go', 'py', 'java', 'sh', 'bat', 'ps1', 'cmd', 'js', 
-	'ts', 'css', 'cpp', 'hpp','h', 'c', 'cs', 'sql', 'log', 'ini',
+	'md', 'rst', 'go', 'py', 'java', 'sh', 'bat', 'ps1', 'cmd', 'js',
+	'ts', 'css', 'cpp', 'hpp', 'h', 'c', 'cs', 'sql', 'log', 'ini',
 	'pl', 'pm', 'r', 'dart', 'dockerfile', 'env', 'php', 'hs',
 	'hsc', 'lua', 'nginxconf', 'conf', 'm', 'mm', 'plsql', 'perl',
 	'rb', 'rs', 'db2', 'scala', 'bash', 'swift', 'vue', 'svelte',
-	'doc','docx', 'pdf', 'csv', 'txt', 'xls', 'xlsx'
+	'doc', 'docx', 'pdf', 'csv', 'txt', 'xls', 'xlsx'
 ];
 
 // Source: https://kit.svelte.dev/docs/modules#$env-static-public
@@ -43,3 +43,5 @@ export const SUPPORTED_FILE_EXTENSIONS = [
 // OLLAMA_API_BASE_URL="http://localhost:11434/api"
 // # Public
 // PUBLIC_API_BASE_URL=$OLLAMA_API_BASE_URL
+
+export const SKIP_WARN_WHEN_OLLAMA_NOT_PRESENT = true

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -24,7 +24,11 @@
 		tags,
 		uiConfigs
 	} from '$lib/stores';
-	import { REQUIRED_OLLAMA_VERSION, WEBUI_API_BASE_URL } from '$lib/constants';
+	import {
+		REQUIRED_OLLAMA_VERSION,
+		SKIP_WARN_WHEN_OLLAMA_NOT_PRESENT,
+		WEBUI_API_BASE_URL
+	} from '$lib/constants';
 
 	import SettingsModal from '$lib/components/chat/SettingsModal.svelte';
 	import Sidebar from '$lib/components/layout/Sidebar.svelte';
@@ -74,7 +78,10 @@
 		ollamaVersion = version;
 
 		console.log(ollamaVersion);
-		if (checkVersion(REQUIRED_OLLAMA_VERSION, ollamaVersion)) {
+		if (
+			checkVersion(REQUIRED_OLLAMA_VERSION, ollamaVersion) &&
+			!SKIP_WARN_WHEN_OLLAMA_NOT_PRESENT
+		) {
 			toast.error(`Ollama Version: ${ollamaVersion !== '' ? ollamaVersion : 'Not Detected'}`);
 		}
 	};
@@ -265,7 +272,7 @@
 					</div>
 				</div>
 			</div>
-		{:else if checkVersion(REQUIRED_OLLAMA_VERSION, ollamaVersion ?? '0')}
+		{:else if checkVersion(REQUIRED_OLLAMA_VERSION, ollamaVersion ?? '0') && !SKIP_WARN_WHEN_OLLAMA_NOT_PRESENT}
 			<div class="fixed w-full h-full flex z-50">
 				<div
 					class="absolute w-full h-full backdrop-blur-md bg-white/20 dark:bg-gray-900/50 flex justify-center"


### PR DESCRIPTION
- hides the initial error messages and backdrop which usually occurs when the webui cannot detect a running ollama backend


This is hidden in the assumption that the webui can still function with just azure or openai baed llm calls